### PR TITLE
Remove warning about unused variable argc

### DIFF
--- a/gti.c
+++ b/gti.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     init_space();
     for (i = -20; i < TERM_WIDTH; i++) {
         draw_car(i);
-        usleep(20*1000);
+        usleep(5*1000);
         clear_car(i);
     }
     execvp(GIT_NAME, argv);


### PR DESCRIPTION
I just cast argc to void to remove the warning. 
