### PR TITLE
Adding support for DESTDIR to Makefile, and a new 'uninstall' target.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
+SHELL=/bin/sh
+
 CC=gcc
 CFLAGS=-O2 -Wall -Wextra
 
 PROG=gti
-PREFIX=/usr/bin
+PREFIX=$(DESTDIR)/usr/bin
 
 $(PROG): *.c
 	$(CC) -o $@ $(CFLAGS) $^
@@ -11,7 +13,10 @@ $(PROG): *.c
 install: $(PROG)
 	cp $^ $(PREFIX)
 
-.PHONY: clean
+uninstall:
+	rm -f $(PREFIX)/$(PROG)
+
+.PHONY: clean install uninstall
 clean:
 	rm -f $(PROG)
 


### PR DESCRIPTION
As per the GNU Makefile Conventions, DESTDIR is a value that can be
prepended to the installation target paths in order to support custom
installation paths, as well as staged installs (where files are placed
in an intermediate path first). It is also used in the Debian packaging
proces (cf. https://www.gnu.org/prep/standards/html_node/DESTDIR.html)

The 'uninstall' target can be used to remove the program, should the
user wish to do so.
