### PR TITLE
Makefile enhancements and a new manual page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,21 +4,31 @@ CC=gcc
 CFLAGS+=-O2 -Wall -Wextra
 
 INSTALL=install -D
+INSTALL_DATA=$(INSTALL) -m 644
 
 BINDIR=$(DESTDIR)/usr/bin
+MANDIR=$(DESTDIR)/usr/share/man/man6
 
 PROG=gti
+MANPAGE=gti.6.gz
 
 $(PROG): *.c
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^
 	-strip -s $@
 
-install: $(PROG)
+
+$(MANPAGE): gti.6
+	gzip -9 -n -c gti.6 > gti.6.gz
+
+install: $(PROG) $(MANPAGE)
 	$(INSTALL) $(PROG) $(BINDIR)
+	$(INSTALL_DATA) $(MANPAGE) $(MANDIR)
 
 uninstall:
 	rm -f $(BINDIR)/$(PROG)
+	rm -f $(MANDIR)/$(MANPAGE)
 
 .PHONY: clean install uninstall
 clean:
 	rm -f $(PROG)
+	rm -f $(MANPAGE)

--- a/gti.6
+++ b/gti.6
@@ -1,0 +1,24 @@
+.TH GTI 6 2013-04-16
+
+.SH NAME
+\fBgti\fP \- Humorous typo-based git runner; drives a car over the terminal.
+
+.SH DESCRIPTION
+\fBgti\fP is intended to catch accidental typos of 'gti' instead of 'git'. It
+displays an animation of a car driving by, and then launches git. Any
+parameters or arguments given to \fBgti\fP will be passed through to git.
+
+The car image is derived from the look of an old VW Golf GTI.
+
+.SH ENVIRONMENT
+\fBgti\fP respects the GIT environment variable. If GIT is set, its value will
+be used to launch git after the animation finishes, instead of searching for
+git in your PATH.
+
+.SH SEE ALSO
+\fBgit\fP(1), \fBsl\fP(6)
+
+.SH AUTHOR
+\fBgti\fP was written by Richard Wossal <richard@r-wos.org>. This manual was
+written by Felix Crux <felixc@felixcrux.com> for the Debian project, but may
+be used by others under the same terms as \fBgti\fP itself.


### PR DESCRIPTION
Hi Richard,

I wanted to share with you some of the additions I made for packaging with Debian, in the hope that they are useful to you too.

I've written up a small manpage, added rules to the Makefile to install/uninstall it, and amended the Makefile to allow users or external utilities such as Debian's packaging systems to add their own compiler, preprocessor, and linker flags.

Let me know if you'd prefer smaller patches with just a subset of these changes. Cheers,

Felix

PS - On a silly bureaucratic note, is it time for a minor version number bump? It would solve some odd policy questions on version numbering for Debian...
