### PR TITLE
Fixing Makefile to allow installation to nonexistent paths.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,12 @@ $(PROG): *.c
 	$(CC) -o $@ $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) $^
 	-strip -s $@
 
-
 $(MANPAGE): gti.6
 	gzip -9 -n -c gti.6 > gti.6.gz
 
 install: $(PROG) $(MANPAGE)
-	$(INSTALL) $(PROG) $(BINDIR)
-	$(INSTALL_DATA) $(MANPAGE) $(MANDIR)
+	$(INSTALL) $(PROG) $(BINDIR)/$(PROG)
+	$(INSTALL_DATA) $(MANPAGE) $(MANDIR)/$(MANPAGE)
 
 uninstall:
 	rm -f $(BINDIR)/$(PROG)


### PR DESCRIPTION
Hi again Richard,

Embarrassingly enough, I introduced a bug in my last pull request! My
apologies for the confusion and constant patches!

Due to a bug in my previous commit (ee56e68), the Makefile could only be
used to install the program and manpage to directories that already exist.

This makes it impossible to use for building into a sandbox environment, or
anywhere that doesn't already have /usr/bin and /usr/share/man/man6. In
particular, this poses problems for packaging.
