### PR TITLE
Always write to terminal, and port to Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ INSTALL_DATA=$(INSTALL) -m 644
 BINDIR=$(DESTDIR)/usr/bin
 MANDIR=$(DESTDIR)/usr/share/man/man6
 
-PROG=gti
+ifeq ($(OS),Windows_NT)
+ X = .exe
+endif
+
+PROG=gti$X
 MANPAGE=gti.6.gz
 
 $(PROG): *.c

--- a/gti.c
+++ b/gti.c
@@ -15,7 +15,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
+#ifndef WIN32
 #include <sys/ioctl.h>
+#else
+#include <windows.h>
+#endif
 #include <string.h>
 
 #define GIT_NAME "git"
@@ -26,6 +30,7 @@
 
 int  term_width(void);
 void init_space(void);
+void open_term();
 void move_to_top(void);
 void line_at(int start_x, const char *s);
 void draw_car(int x);
@@ -39,9 +44,7 @@ int main(int argc, char **argv)
 {
     (void) argc;
     int i;
-    TERM_FH = fopen("/dev/tty", "w");
-    if (!TERM_FH)
-        TERM_FH = stdout;
+    open_term();
     TERM_WIDTH = term_width();
     SLEEP_DELAY = 1000000 / (TERM_WIDTH + GTI_SPEED);
 
@@ -64,6 +67,20 @@ int main(int argc, char **argv)
     return 1;
 }
 
+void init_space(void)
+{
+    fputs("\n\n\n\n\n\n", TERM_FH); /* 7 lines */
+}
+
+#ifndef WIN32
+
+void open_term()
+{
+    TERM_FH = fopen("/dev/tty", "w");
+    if (!TERM_FH)
+        TERM_FH = stdout;
+}
+
 int term_width(void)
 {
     struct winsize w;
@@ -71,26 +88,76 @@ int term_width(void)
     return w.ws_col;
 }
 
-void init_space(void)
-{
-    fputs("\n\n\n\n\n\n", TERM_FH); /* 7 lines */
-}
-
 void move_to_top(void)
 {
     fprintf(TERM_FH, "\033[7A");
 }
+
+void move_to_x(int x)
+{
+    fprintf(TERM_FH, "\033[%dC", x);
+}
+
+#else
+
+HANDLE con;
+
+void open_term()
+{
+    TERM_FH = fopen("CONOUT$", "w+");
+    con = (HANDLE)_get_osfhandle(fileno(TERM_FH));
+
+    /*
+     * Both buffered and non-buffered access to the same handle is
+     * recepie for disaster. Disable buffering.
+     */
+    setvbuf(TERM_FH, NULL, _IONBF, 0);
+}
+
+int term_width(void)
+{
+    CONSOLE_SCREEN_BUFFER_INFO ci;
+    GetConsoleScreenBufferInfo(con, &ci);
+    return ci.dwSize.X;
+}
+
+void move_to_top(void)
+{
+    CONSOLE_SCREEN_BUFFER_INFO ci;
+    GetConsoleScreenBufferInfo(con, &ci);
+    ci.dwCursorPosition.X = 0;
+    ci.dwCursorPosition.Y -= 7;
+    SetConsoleCursorPosition(con, ci.dwCursorPosition);
+}
+
+void move_to_x(int x)
+{
+    CONSOLE_SCREEN_BUFFER_INFO ci;
+    GetConsoleScreenBufferInfo(con, &ci);
+    ci.dwCursorPosition.X = x;
+    SetConsoleCursorPosition(con, ci.dwCursorPosition);
+}
+
+#endif
 
 void line_at(int start_x, const char *s)
 {
     int x;
     size_t i;
     if (start_x > 1)
-        fprintf(TERM_FH, "\033[%dC", start_x);
+        move_to_x(start_x);
     for (x = start_x, i = 0; i < strlen(s); x++, i++) {
         if (x > 0 && x < TERM_WIDTH)
             fputc(s[i], TERM_FH);
     }
+#ifdef WIN32
+    /*
+     * It seems Windows wraps on whe cursor when it's about to overflow,
+     * rather than after it has overflown (unless the overflowing character
+     * is a newline), as other systems seems to do.
+     */
+    if (x < TERM_WIDTH)
+#endif
     fputc('\n', TERM_FH);
 }
 


### PR DESCRIPTION
I'm submitting these together, as one depends on the other.

These patches makes Gti write to the TTY when possible, and ports the code to run on Windows.
