### PR TITLE
8 lines created instead of 7 to not erase the PS1 line during the refresh

### DIFF
--- a/gti.c
+++ b/gti.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv)
 
 void init_space(void)
 {
-    fputs("\n\n\n\n\n\n", TERM_FH); /* 7 lines */
+    fputs("\n\n\n\n\n\n\n", TERM_FH); /* 8 lines, to not remove the PS1 line */
 }
 
 #ifndef WIN32


### PR DESCRIPTION
With the current version, when gti is ran, the PS1 line is deleted.
Tere my empty prompt, followed by the result of the master's version of gti and then followed by this branch's version:

```
ghislain@debian: ~/dev-perso/gti (ps1-deletion-fix)
> 
ghislain@debian: ~/dev-perso/gti (ps1-deletion-fix)
On branch ps1-deletion-fix
[...]
ghislain@debian: ~/dev-perso/gti (ps1-deletion-fix)
> ./gti st
On branch ps1-deletion-fix
[...]
```

It also happens on a one-line PS1 (The first prompt line is a no command prompt, I just pressed enter to get a new one where I typed gti status):

```
root@debian:/home/ghislain/dev-perso/gti# 
On branch ps1-deletion-fix
[...]
root@debian:/home/ghislain/dev-perso/gti# ./gti status
On branch ps1-deletion-fix
[...]
```

I've been able to reproduce it on Unix based systems (Debian, CentOs and OSX), but I have no windows to test it there.
