### PR TITLE
Change DESTDIR to allow installation to $HOME/.local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,9 @@ CFLAGS+=-O2 -std=c89 -Wpedantic -Wall -Wextra -Wunused -Wshadow -Wdouble-promoti
 INSTALL=install -D
 INSTALL_DATA=$(INSTALL) -m 644
 
-BINDIR=$(DESTDIR)/usr/bin
-MANDIR=$(DESTDIR)/usr/share/man/man6
+DESTDIR=/usr
+BINDIR=$(DESTDIR)/bin
+MANDIR=$(DESTDIR)/share/man/man6
 
 STRIP=strip
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
I am not really a C or C++ dev but I hope the way I hacked this is acceptable.
My goal was to install it to $HOME/.local. You can achieve this now by doing ``make install DESTDIR=~/.local``.

Maybe this should be added to the README but I am unsure.