### PR TITLE
Set stdout to full buffer instead of opening again

### DIFF
--- a/gti.c
+++ b/gti.c
@@ -143,7 +143,7 @@ void open_term()
 {
 #ifndef WIN32
     TERM_FH = stdout;
-    if (!setvbuf(TERM_FH, NULL, _IOFBF, BUFSIZ))
+    if (setvbuf(TERM_FH, NULL, _IOFBF, BUFSIZ))
         perror("setvbuf");
 #else
     TERM_FH = fopen("CONOUT$", "w+");


### PR DESCRIPTION
As I believe that is what you were trying to achieve by opening the
`/dev/tty` again in read mode...