### PR TITLE
Do not use -D flag for install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ prefix=$(DESTDIR)/usr
 CC=cc
 CFLAGS+=-O2 -std=c89 -Wpedantic -Wall -Wextra -Wunused -Wshadow -Wdouble-promotion -Wstrict-overflow=5
 
-INSTALL=install -D
+INSTALL=install
 INSTALL_DATA=$(INSTALL) -m 644
 
 bindir=$(prefix)/bin


### PR DESCRIPTION
The `-D` flag is a GNU extension not available on BSD `install` (e.g. on macOS).

See #56

Fixes:

```
install: illegal option -- D
usage: install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 file2
       install [-bCcpSsv] [-B suffix] [-f flags] [-g group] [-m mode]
               [-o owner] file1 ... fileN directory
       install -d [-v] [-g group] [-m mode] [-o owner] directory ...
```