### PR TITLE
Fix implicit declaration of function 'usleep'

### DIFF
--- a/gti.c
+++ b/gti.c
@@ -16,7 +16,7 @@
 #    define WIN32
 #else
      /* fileno() */
-#    define _POSIX_C_SOURCE 1
+#    define _POSIX_C_SOURCE 199506L
      /* usleep() */
 #    define _DEFAULT_SOURCE
 #endif


### PR DESCRIPTION
gti (1.7.0) fails to build on macOS (10.15.7) with Xcode 12 or later:

```
gti.c:234:5: error: implicit declaration of function 'usleep' [-Werror,-Wimplicit-function-declaration]
    usleep(FRAME_TIME);
    ^
gti.c:234:5: note: did you mean 'sleep'?
/Library/Developer/CommandLineTools/SDKs/MacOSX10.15.sdk/usr/include/unistd.h:481:3: note: 'sleep' declared here
         sleep(unsigned int) __DARWIN_ALIAS_C(sleep);
         ^
gti.c:258:5: error: implicit declaration of function 'usleep' [-Werror,-Wimplicit-function-declaration]
    usleep(FRAME_TIME * 10);
    ^
gti.c:282:5: error: implicit declaration of function 'usleep' [-Werror,-Wimplicit-function-declaration]
    usleep(FRAME_TIME * 8);
    ^
gti.c:309:5: error: implicit declaration of function 'usleep' [-Werror,-Wimplicit-function-declaration]
    usleep(FRAME_TIME * 2);
    ^
4 errors generated.
```

With Xcode 12 and later, implicit declaration of functions is an error.

You are defining `_POSIX_C_SOURCE`. By doing this, depending on what value you set it to, you are telling the system headers to hide certain declarations; `usleep` is hidden on macOS unless `_POSIX_C_SOURCE` is either undefined or is `199506L` or greater.

This was originally reported to MacPorts in https://trac.macports.org/ticket/62436.

If changing the value of `_POSIX_C_SOURCE` causes problems for other operating systems, then an alternative is to define `_DARWIN_C_SOURCE`:

```diff
--- gti.c.orig	2020-02-09 07:59:44.000000000 -0600
+++ gti.c	2022-03-30 21:21:53.000000000 -0500
@@ -19,6 +19,7 @@
 #    define _POSIX_C_SOURCE 1
      /* usleep() */
 #    define _DEFAULT_SOURCE
+#    define _DARWIN_C_SOURCE
 #endif
 
 #include <stdio.h>
```