### PR TITLE
Fix _POSIX_C_SOURCE on z/OS

### DIFF
--- a/gti.c
+++ b/gti.c
@@ -16,7 +16,12 @@
 #    define WIN32
 #else
      /* fileno() */
+#if defined(__MVS__)
+     /* _POSIX_C_SOURCE has to be 1, 2 or 200112L on z/OS */
+#    define _POSIX_C_SOURCE 200112L
+#else
 #    define _POSIX_C_SOURCE 199506L
+#endif
      /* usleep() */
 #    define _DEFAULT_SOURCE
 #endif


### PR DESCRIPTION
This allows compiling on z/OS again, 733fccfb5607f94e1202fb4cdbd17850501e9faf caused a regression by defining _POSIX_C_SOURCE as 199506L. On z/OS only 1, 2, and 200112L are valid values.